### PR TITLE
fix: Remove invalid position property from Offer type in LD-JSON schemas (v2.2.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to the 84EM Local Pages Generator plugin will be documented 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.2.3] - 2025-08-04
+
+### Fixed
+- Removed invalid `position` property from Offer type in LD-JSON schemas
+- Position property is only valid for ListItem types (BreadcrumbList, ItemList), not Offer
+- OfferCatalog schema now fully compliant with schema.org specifications
+
 ## [2.2.2] - 2025-08-04
 
 ### Added

--- a/Claude.md
+++ b/Claude.md
@@ -396,6 +396,11 @@ The `--generate-sitemap` command creates XML sitemaps. This command:
 
 ## Version History
 
+### v2.2.3 (August 4, 2025)
+- **FIXED**: Removed invalid `position` property from Offer type in LD-JSON schemas
+- **FIXED**: Position is only valid for ListItem types (BreadcrumbList, ItemList), not Offer
+- **IMPROVED**: OfferCatalog schema now fully compliant with schema.org specifications
+
 ### v2.2.2 (August 4, 2025)
 - **NEW**: Added `--regenerate-schema` command to fix schema issues without regenerating content
 - **NEW**: Schema regeneration supports all pages, states-only, specific states, and specific cities
@@ -462,4 +467,4 @@ The `--generate-sitemap` command creates XML sitemaps. This command:
 **API Version**: 2023-06-01  
 **Content Strategy**: Hierarchical location pages with automatic interlinking  
 **Total Pages**: 350 (50 states + 300 cities)  
-**Plugin Version**: 2.1.2
+**Plugin Version**: 2.2.3


### PR DESCRIPTION
Fixes:
- Remove position property from Offer type in hasOfferCatalog
- Position is only valid for ListItem types (BreadcrumbList, ItemList)
- OfferCatalog schema now fully compliant with schema.org specifications
- Fix additional schema validation errors reported by SEO tools

Changes:
- Update plugin version to 2.2.3
- Update all documentation with schema fix details
- Clean up whitespace formatting

🤖 Generated with [Claude Code](https://claude.ai/code)