### PR TITLE
Enhances SEO title with "Expert" qualifier

### DIFF
--- a/src/Content/CityContentGenerator.php
+++ b/src/Content/CityContentGenerator.php
@@ -190,7 +190,7 @@ class CityContentGenerator implements ContentGeneratorInterface {
                     '_local_page_city'      => $city,
                     '_local_page_generated' => current_time( 'mysql' ),
                     '_genesis_description' => "Professional WordPress development, custom plugins, and web solutions for businesses in {$city}, {$state}. White-label services and expert support.",
-                    '_genesis_title'    => "WordPress Development Services in {$city}, {$state} | 84EM",
+                    '_genesis_title'    => "Expert WordPress Development Services in {$city}, {$state} | 84EM",
                 ],
             ];
 
@@ -250,7 +250,7 @@ class CityContentGenerator implements ContentGeneratorInterface {
             // Update metadata
             update_post_meta( $post_id, '_local_page_generated', current_time( 'mysql' ) );
             update_post_meta( $post_id, '_genesis_description', "Professional WordPress development, custom plugins, and web solutions for businesses in {$city}, {$state}. White-label services and expert support." );
-            update_post_meta( $post_id, '_genesis_title', "WordPress Development Services in {$city}, {$state} | 84EM" );
+            update_post_meta( $post_id, '_genesis_title', "Expert WordPress Development Services in {$city}, {$state} | 84EM" );
 
             // Regenerate schema
             $schema = $this->schemaGenerator->generateCitySchema( $state, $city );

--- a/src/Content/StateContentGenerator.php
+++ b/src/Content/StateContentGenerator.php
@@ -174,7 +174,7 @@ class StateContentGenerator implements ContentGeneratorInterface {
                 'meta_input'   => [
                     '_local_page_state'      => $state,
                     '_genesis_description' => "Professional WordPress development, custom plugins, and web solutions for businesses in {$state}. White-label services for agencies in " . implode( ', ', $cities ) . ".",
-                    '_genesis_title'     => "WordPress Development Services in {$state} | 84EM",
+                    '_genesis_title'     => "Expert WordPress Development Services in {$state} | 84EM",
                 ],
             ];
 
@@ -239,7 +239,7 @@ class StateContentGenerator implements ContentGeneratorInterface {
 
             // Update meta fields
             update_post_meta( $post_id, '_genesis_description', "Professional WordPress development, custom plugins, and web solutions for businesses in {$state}. White-label services for agencies in " . implode( ', ', $cities ) . "." );
-            update_post_meta( $post_id, '_genesis_title', "WordPress Development Services in {$state} | 84EM" );
+            update_post_meta( $post_id, '_genesis_title', "Expert WordPress Development Services in {$state} | 84EM" );
 
             // Regenerate and save schema
             $schema = $this->schemaGenerator->generateStateSchema( $state );


### PR DESCRIPTION
Updates page titles across city and state content generators to include "Expert" before "WordPress Development Services" for improved positioning and search visibility

Strengthens brand authority and helps differentiate service offerings in search results