### PR TITLE
v3.2.2

### DIFF
--- a/84em-local-pages.php
+++ b/84em-local-pages.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: 84EM Local Pages Generator
  * Description: Generates SEO-optimized Local Pages for each US state using Claude AI. Includes WP-CLI testing framework.
- * Version: 3.2.1
+ * Version: 3.2.2
  * Author: 84EM
  * Requires at least: 6.8
  * Requires PHP: 8.2
@@ -12,7 +12,7 @@
 defined( 'ABSPATH' ) or die;
 
 // Define plugin constants
-const EIGHTYFOUREM_LOCAL_PAGES_VERSION = '3.2.1';
+const EIGHTYFOUREM_LOCAL_PAGES_VERSION = '3.2.2';
 
 // Load Composer autoloader
 if ( file_exists( __DIR__ . '/vendor/autoload.php' ) ) {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to the 84EM Local Pages Generator plugin will be documented 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.2.2] - 2025-08-18
+
+### Changed
+- **Content Generation Prompts**: Updated AI prompts for both state and city pages
+  - Added instruction to mention that 84EM is headquartered in Cedar Rapids, Iowa
+  - Removed requirement to use the specific phrase "remote-first"
+  - Maintains emphasis on 100% fully remote operations
+  - Helps establish company credibility with headquarters location
+
 ## [3.2.1] - 2025-08-18
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -331,10 +331,10 @@ https://84em.com/wordpress-development-services-texas/dallas/
 
 **State Pages:**
 - ✅ City names → Link to city pages
-- ✅ Service keywords → Link to https://84em.com/contact/
+- ✅ Service keywords → Link to service pages
 
 **City Pages:**
-- ✅ Service keywords → Link to https://84em.com/contact/
+- ✅ Service keywords → Link to service pages
 
 ### SEO Implementation
 

--- a/src/Content/CityContentGenerator.php
+++ b/src/Content/CityContentGenerator.php
@@ -301,7 +301,7 @@ class CityContentGenerator implements ContentGeneratorInterface {
 
 IMPORTANT: Create unique, original content that is different from other city pages. Focus on local relevance through city-specific benefits and geographic context.
 
-84EM is a 100% FULLY REMOTE WordPress development company. Do NOT mention on-site visits, in-person consultations, local offices, or physical presence. All work is done remotely.
+84EM is a 100% FULLY REMOTE WordPress development company. Do NOT mention on-site visits, in-person consultations, local offices, or physical presence. All work is done remotely.  But DO mention that 84EM is headquartered in Cedar Rapids, Iowa.  No need to specifically use the phrase \"remote-first\"
 
 Include the following key elements:
 1. A professional opening paragraph mentioning {$city}, {$state} and local business benefits

--- a/src/Content/StateContentGenerator.php
+++ b/src/Content/StateContentGenerator.php
@@ -286,7 +286,7 @@ class StateContentGenerator implements ContentGeneratorInterface {
 
 IMPORTANT: Create unique, original content that is different from other state pages. Focus on local relevance through city mentions and state-specific benefits.
 
-84EM is a 100% FULLY REMOTE WordPress development company. Do NOT mention on-site visits, in-person consultations, local offices, or physical presence. All work is done remotely.
+84EM is a 100% FULLY REMOTE WordPress development company. Do NOT mention on-site visits, in-person consultations, local offices, or physical presence. All work is done remotely.  But DO mention that 84EM is headquartered in Cedar Rapids, Iowa.  No need to specifically use the phrase \"remote-first\"
 
 Include the following key elements:
 1. A professional opening paragraph mentioning {$state} and ALL of these cities: {$city_list} (you MUST mention all 6 cities)


### PR DESCRIPTION
This pull request updates the 84EM Local Pages Generator plugin to version 3.2.2, focusing on improvements to the AI-generated content for state and city pages. The main changes clarify how the company’s headquarters and remote operations are presented in generated content, and update documentation to reflect service page linking.

**Content Generation Improvements:**

* Updated AI prompts in both `StateContentGenerator.php` and `CityContentGenerator.php` to instruct the AI to mention that 84EM is headquartered in Cedar Rapids, Iowa, while maintaining the emphasis on 100% fully remote operations. The explicit requirement to use the phrase "remote-first" was removed. [[1]](diffhunk://#diff-9a7ac3c54a2e87a655757279663d362dc085411f85c73e9304d0a988ae1c1891L289-R289) [[2]](diffhunk://#diff-895a84ff8d8b6b1282de70f35e0c609e2b898565bd7a4839578313100c96a143L304-R304)

**Documentation and Linking Updates:**

* Updated the `README.md` to clarify that service keywords now link to service pages instead of the contact page, for both state and city pages.
* Added a changelog entry in `CHANGELOG.md` for version 3.2.2, describing the prompt changes and their intent to establish company credibility.

**Version Bump:**

* Updated the plugin version to 3.2.2 in both the plugin header and the version constant in `84em-local-pages.php`. [[1]](diffhunk://#diff-cc40f0b77797c910612444cd00c52a730c6244fee14ca040e7ca5acd65898e03L5-R5) [[2]](diffhunk://#diff-cc40f0b77797c910612444cd00c52a730c6244fee14ca040e7ca5acd65898e03L15-R15)